### PR TITLE
Create wikipedia-joins.json

### DIFF
--- a/src/events/wikipedia-joins.json
+++ b/src/events/wikipedia-joins.json
@@ -1,0 +1,6 @@
+{
+  "type": "news",
+  "date": "2023-04-12",
+  "title": "Wikipedia joins the fediverse",
+  "description": "The Free Online Encyclopedia, Wikipedia, joins the fediverse at @wikipedia@wikis.world. It is used as a notable example for the Mastodon verified links feature."
+}


### PR DESCRIPTION
### 2023-04-12
- Title: Wikipedia joins the fediverse
- Content: The Free Online Encyclopedia, Wikipedia, joins the fediverse at @wikipedia@wikis.world. It is used as a notable example for the Mastodon verified links feature.